### PR TITLE
feat: don't change the original font of some numbers

### DIFF
--- a/Plugin/ChineseFont.cs
+++ b/Plugin/ChineseFont.cs
@@ -74,6 +74,10 @@ public static class ChineseFont
 	[HarmonyPostfix]
 	private static void UpdateTMP(TextMeshProLanguageSetter __instance)
 	{
+		if (__instance._text.font.name == "ExcelsiorSans SDF")
+		{
+			return;
+		}
 		__instance._text.font = Tmpchinesefonts[0];
 		if (__instance._text.overflowMode == TextOverflowModes.Ellipsis)
 			__instance._text.overflowMode = TextOverflowModes.Overflow;


### PR DESCRIPTION
調整部分數字字體使用原始字體(`ExcelsiorSans SDF`)

已知影響以下欄位:
- `[Text]Minus`: 腦啡肽模組消耗數字
- `Tmp_PiecesCounter`: 商店交換人格碎片數字分子
- `Tmp_PriceText`: 商店交換人格碎片數字分母
